### PR TITLE
Add support for ipa v3 nodes. This is handy during migration process …

### DIFF
--- a/checkipaconsistency/main.py
+++ b/checkipaconsistency/main.py
@@ -117,7 +117,7 @@ class Main(object):
 
         self._servers = OrderedDict()
         for host in self._hosts:
-            self._servers[host] = FreeIPAServer(host, self._domain, self._binddn, self._bindpw)
+            self._servers[host] = FreeIPAServer(host, self._domain, self._binddn, self._bindpw, self._args.support_ipa3)
 
         self._checks = OrderedDict([
             ('users', 'Active Users'),
@@ -154,6 +154,8 @@ class Main(object):
                             help='log to file (./%s.log by default)' % self._app_name)
         parser.add_argument('--no-header', action='store_true', dest='disable_header', help='disable table header')
         parser.add_argument('--no-border', action='store_true', dest='disable_border', help='disable table border')
+        parser.add_argument('--support-ipa3', action='store_true', dest='support_ipa3',
+                            help='enable support for ipa v3 nodes, which is usable for migration workflows')
         parser.add_argument('-n', nargs='?', dest='nagios_check', help='Nagios plugin mode', default='not_set',
                             choices=['', 'all', 'users', 'susers', 'pusers', 'hosts', 'services', 'ugroups', 'hgroups',
                                      'ngroups', 'hbac', 'sudo', 'zones', 'certs', 'conflicts', 'ghosts', 'bind',


### PR DESCRIPTION
…when you have both ipa v3 and ipa v4 nodes in the same IPA cluster

This comes handy during migration process when you have both ipa v3 and ipa v4 nodes in the same IPA cluster and one to verify that replication between old ipa v3 nodes and new ipa v4 nodes woks correctly.

Without this change cipa always returns '0' as a number of certificates on ipa v3 hosts.

This change adds a new flag to cipa utility --support_ipa3 which enables new parts of code which take into account the fact that on ipa v3 nodes slapd-pki is a separate daemon which listens on port 7389.